### PR TITLE
add undeclared dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -656,6 +656,36 @@
 				"trim-right": "^1.0.1",
 				"unique-temp-dir": "^1.0.0",
 				"update-notifier": "^2.5.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				}
 			}
 		},
 		"babel-plugin-espower": {
@@ -1131,14 +1161,20 @@
 			}
 		},
 		"cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.0.tgz",
+			"integrity": "sha512-6U/8SMK2FBNnB21oQ4+6Nsodxanw1gTkntYA2zBdkFYFu3ZDx65P2ONEXGSvob/QS6REjVHQ9zxzdOafwFdstw==",
 			"requires": {
-				"lru-cache": "^4.0.1",
+				"path-key": "^3.1.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
+			},
+			"dependencies": {
+				"path-key": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+					"integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg=="
+				}
 			}
 		},
 		"crypto-random-string": {
@@ -1434,6 +1470,19 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				}
 			}
 		},
 		"expand-brackets": {
@@ -1611,12 +1660,19 @@
 			}
 		},
 		"find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-			"dev": true,
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 			"requires": {
-				"locate-path": "^3.0.0"
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"dependencies": {
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				}
 			}
 		},
 		"for-in": {
@@ -1660,7 +1716,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1681,12 +1738,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1701,17 +1760,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1828,7 +1890,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1840,6 +1903,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1854,6 +1918,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -1861,12 +1926,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -1885,6 +1952,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1965,7 +2033,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1977,6 +2046,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2062,7 +2132,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2098,6 +2169,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2117,6 +2189,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2160,12 +2233,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -2251,6 +2326,12 @@
 				"slash": "^1.0.0"
 			},
 			"dependencies": {
+				"ignore": {
+					"version": "3.3.10",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+					"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+					"dev": true
+				},
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -2329,10 +2410,9 @@
 			"dev": true
 		},
 		"ignore": {
-			"version": "3.3.10",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-			"dev": true
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+			"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
 		},
 		"ignore-by-default": {
 			"version": "1.0.1",
@@ -2668,8 +2748,7 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -2748,13 +2827,11 @@
 			}
 		},
 		"locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-			"dev": true,
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 			"requires": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "^4.1.0"
 			}
 		},
 		"lodash": {
@@ -3233,21 +3310,19 @@
 			"dev": true
 		},
 		"p-limit": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
-			"dev": true,
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+			"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 			"requires": {
 				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-			"dev": true,
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 			"requires": {
-				"p-limit": "^2.0.0"
+				"p-limit": "^2.2.0"
 			}
 		},
 		"p-map": {
@@ -3257,10 +3332,9 @@
 			"dev": true
 		},
 		"p-try": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-			"dev": true
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"package-hash": {
 			"version": "2.0.0",
@@ -3436,6 +3510,36 @@
 			"dev": true,
 			"requires": {
 				"find-up": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				}
 			}
 		},
 		"plur": {
@@ -3838,7 +3942,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -3846,8 +3949,7 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -4573,7 +4675,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -45,5 +45,11 @@
 		"require": [
 			"ts-node/register"
 		]
+	},
+	"dependencies": {
+		"cross-spawn": "^7.0.0",
+		"find-up": "^4.1.0",
+		"ignore": "^5.1.4",
+		"locate-path": "^5.0.0"
 	}
 }


### PR DESCRIPTION
This library depends on plenty of things, but the dependencies aren't declared.

The build passes locally because `ava` happens to depend on all of them too.

Declare the dependencies, at the current latest version; significantly newer than what `ava` was declaring before. The tests pass for me.